### PR TITLE
Add ability to execute scripts inside a script scope

### DIFF
--- a/gamedata/vscript.txt
+++ b/gamedata/vscript.txt
@@ -174,6 +174,12 @@
 				"windows"	"10"
 			}
 			
+			"IScriptVM::ReleaseScript"
+			{
+				"linux"		"9"
+				"windows"	"11"
+			}
+			
 			"IScriptVM::ExecuteFunction"
 			{
 				"linux"		"17"
@@ -317,6 +323,18 @@
 			{
 				"linux"		"60"
 				"windows"	"60"
+			}
+			
+			"IScriptVM::CompileScript"
+			{
+				"linux"		"9"
+				"windows"	"11"
+			}
+			
+			"IScriptVM::ReleaseScript"
+			{
+				"linux"		"10"
+				"windows"	"12"
 			}
 		}
 	}

--- a/gamedata/vscript.txt
+++ b/gamedata/vscript.txt
@@ -170,14 +170,14 @@
 			
 			"IScriptVM::CompileScript"	// vtable dumper got it wrong
 			{
-				"linux"		"8"
-				"windows"	"10"
+				"linux"		"9"
+				"windows"	"11"
 			}
 			
 			"IScriptVM::ReleaseScript"
 			{
-				"linux"		"9"
-				"windows"	"11"
+				"linux"		"10"
+				"windows"	"12"
 			}
 			
 			"IScriptVM::ExecuteFunction"
@@ -323,18 +323,6 @@
 			{
 				"linux"		"60"
 				"windows"	"60"
-			}
-			
-			"IScriptVM::CompileScript"
-			{
-				"linux"		"9"
-				"windows"	"11"
-			}
-			
-			"IScriptVM::ReleaseScript"
-			{
-				"linux"		"10"
-				"windows"	"12"
 			}
 		}
 	}

--- a/scripting/include/vscript.inc
+++ b/scripting/include/vscript.inc
@@ -87,6 +87,9 @@ methodmap HSCRIPT < Address
 	
 	// Frees a HSCRIPT memory
 	public native void Release();
+
+	// Frees a HSCRIPT memory. This is only used for compiled scripts.
+	public native void ReleaseScript();
 }
 
 // Several functions accept null HScript as g_pScriptVM for root table
@@ -222,7 +225,7 @@ methodmap VScriptExecute < Handle
 	// 
 	// @param script           Script address to execute.
 	// @param scope            The script scope to execute the script inside of.
-	public native VScriptExecute(HSCRIPT script, HSCRIPT scope = view_as<HSCRIPT>(0));
+	public native VScriptExecute(HSCRIPT script, HSCRIPT scope = HSCRIPT_RootTable);
 	
 	// Adds a new parameter at the end
 	// 
@@ -266,7 +269,7 @@ native void VScript_ResetScriptVM();
  * @param script           Script to compile
  * @param id               Optional ID to set
  * 
- * @return                 HSCRIPT of script, null if could not compile. This MUST be freed when not in use by using VScript_ReleaseScript().
+ * @return                 HSCRIPT of script, null if could not compile. This MUST be freed when not in use by using HSCRIPT.ReleaseScript().
  */
 native HSCRIPT VScript_CompileScript(const char[] script, const char[] id = NULL_STRING);
 
@@ -275,17 +278,10 @@ native HSCRIPT VScript_CompileScript(const char[] script, const char[] id = NULL
  * 
  * @param filepath         Filepath to get a script, 'scripts/vscripts/' are automatically added to the filepath
  * 
- * @return                 HSCRIPT of script, null if could not compile. This MUST be freed when not in use by using VScript_ReleaseScript().
+ * @return                 HSCRIPT of script, null if could not compile. This MUST be freed when not in use by using HSCRIPT.ReleaseScript().
  * @error                  Invalid filepath.
  */
 native HSCRIPT VScript_CompileScriptFile(const char[] filepath);
-
-/**
- * Releases a compiled script.
- * 
- * @param hscript          HSCRIPT of compiled script
- */
-native void VScript_ReleaseScript(HSCRIPT hscript);
 
 /**
  * Creates a new HSCRIPT table, it MUST be deleted when no longer needed by using HSCRIPT.Release()
@@ -410,7 +406,8 @@ public void __pl_vscript_SetNTVOptional()
 	MarkNativeAsOptional("HSCRIPT.SetValue");
 	MarkNativeAsOptional("HSCRIPT.SetValueString");
 	MarkNativeAsOptional("HSCRIPT.Release");
-	
+	MarkNativeAsOptional("HSCRIPT.ReleaseScript");
+
 	MarkNativeAsOptional("VScriptFunction.GetScriptName");
 	MarkNativeAsOptional("VScriptFunction.GetDescription");
 	MarkNativeAsOptional("VScriptFunction.Binding.get");
@@ -431,7 +428,6 @@ public void __pl_vscript_SetNTVOptional()
 	MarkNativeAsOptional("VScript_ResetScriptVM");
 	MarkNativeAsOptional("VScript_CompileScript");
 	MarkNativeAsOptional("VScript_CompileScriptFile");
-	MarkNativeAsOptional("VScript_ReleaseScript");
 	MarkNativeAsOptional("VScript_CreateTable");
 	MarkNativeAsOptional("VScript_GetAllClasses");
 	MarkNativeAsOptional("VScript_GetClass");

--- a/scripting/include/vscript.inc
+++ b/scripting/include/vscript.inc
@@ -221,7 +221,8 @@ methodmap VScriptExecute < Handle
 	// Creates a new handle to execute a script function
 	// 
 	// @param script           Script address to execute.
-	public native VScriptExecute(HSCRIPT script);
+	// @param scope            The script scope to execute the script inside of.
+	public native VScriptExecute(HSCRIPT script, HSCRIPT scope = view_as<HSCRIPT>(0));
 	
 	// Adds a new parameter at the end
 	// 
@@ -265,7 +266,7 @@ native void VScript_ResetScriptVM();
  * @param script           Script to compile
  * @param id               Optional ID to set
  * 
- * @return                 HSCRIPT of script, null if could not compile. This MUST be freed when not in use by using HSCRIPT.Release()
+ * @return                 HSCRIPT of script, null if could not compile. This MUST be freed when not in use by using VScript_ReleaseScript().
  */
 native HSCRIPT VScript_CompileScript(const char[] script, const char[] id = NULL_STRING);
 
@@ -274,10 +275,17 @@ native HSCRIPT VScript_CompileScript(const char[] script, const char[] id = NULL
  * 
  * @param filepath         Filepath to get a script, 'scripts/vscripts/' are automatically added to the filepath
  * 
- * @return                 HSCRIPT of script, null if could not compile. This MUST be freed when not in use by using HSCRIPT.Release()
+ * @return                 HSCRIPT of script, null if could not compile. This MUST be freed when not in use by using VScript_ReleaseScript().
  * @error                  Invalid filepath.
  */
 native HSCRIPT VScript_CompileScriptFile(const char[] filepath);
+
+/**
+ * Releases a compiled script.
+ * 
+ * @param hscript          HSCRIPT of compiled script
+ */
+native void VScript_ReleaseScript(HSCRIPT hscript);
 
 /**
  * Creates a new HSCRIPT table, it MUST be deleted when no longer needed by using HSCRIPT.Release()
@@ -423,6 +431,7 @@ public void __pl_vscript_SetNTVOptional()
 	MarkNativeAsOptional("VScript_ResetScriptVM");
 	MarkNativeAsOptional("VScript_CompileScript");
 	MarkNativeAsOptional("VScript_CompileScriptFile");
+	MarkNativeAsOptional("VScript_ReleaseScript");
 	MarkNativeAsOptional("VScript_CreateTable");
 	MarkNativeAsOptional("VScript_GetAllClasses");
 	MarkNativeAsOptional("VScript_GetClass");

--- a/scripting/vscript/execute.sp
+++ b/scripting/vscript/execute.sp
@@ -11,6 +11,7 @@ enum struct Execute
 {
 	HSCRIPT pHScript;
 	ExecuteParam nReturn;
+	HSCRIPT hScope;
 }
 
 static Handle g_hSDKCallExecuteFunction;
@@ -20,14 +21,13 @@ void Execute_LoadGamedata(GameData hGameData)
 	g_hSDKCallExecuteFunction = CreateSDKCall(hGameData, "IScriptVM", "ExecuteFunction", SDKType_PlainOldData, SDKType_PlainOldData, SDKType_PlainOldData, SDKType_PlainOldData, SDKType_PlainOldData, SDKType_PlainOldData, SDKType_Bool);
 }
 
-/* TODO execute a function from a scope, so we can pass scope param */
-
-VScriptExecute Execute_Create(HSCRIPT pHScript)
+VScriptExecute Execute_Create(HSCRIPT pHScript, HSCRIPT hScope)
 {
 	ArrayList aExecute = new ArrayList(sizeof(Execute));
 	
 	Execute execute;
 	execute.pHScript = pHScript;
+	execute.hScope = hScope;
 	aExecute.PushArray(execute);
 	return view_as<VScriptExecute>(aExecute);
 }
@@ -101,7 +101,7 @@ ScriptStatus_t Execute_Execute(VScriptExecute aExecute)
 		hArgs.StoreToOffset((iParam * g_iScriptVariant_sizeof) + g_iScriptVariant_union, nValue, NumberType_Int32);
 	}
 	
-	ScriptStatus_t nStatus = SDKCall(g_hSDKCallExecuteFunction, GetScriptVM(), execute.pHScript, hArgs ? hArgs.Address : Address_Null, iNumParams, pReturn.Address, 0, true);
+	ScriptStatus_t nStatus = SDKCall(g_hSDKCallExecuteFunction, GetScriptVM(), execute.pHScript, hArgs ? hArgs.Address : Address_Null, iNumParams, pReturn.Address, execute.hScope, true);
 	
 	execute.nReturn.nType = pReturn.nType;
 	execute.nReturn.nValue = pReturn.nValue;

--- a/scripting/vscript/hscript.sp
+++ b/scripting/vscript/hscript.sp
@@ -4,6 +4,7 @@ static Handle g_hSDKCallGetValue;
 static Handle g_hSDKCallSetValueString;
 static Handle g_hSDKCallSetValue;
 static Handle g_hSDKCallReleaseValue;
+static Handle g_hSDKCallReleaseScript;
 
 void HScript_LoadGamedata(GameData hGameData)
 {
@@ -13,6 +14,7 @@ void HScript_LoadGamedata(GameData hGameData)
 	g_hSDKCallSetValueString = CreateSDKCall(hGameData, "IScriptVM", "SetValueString", SDKType_Bool, SDKType_PlainOldData, SDKType_String, SDKType_String);
 	g_hSDKCallSetValue = CreateSDKCall(hGameData, "IScriptVM", "SetValue", SDKType_Bool, SDKType_PlainOldData, SDKType_String, SDKType_PlainOldData);
 	g_hSDKCallReleaseValue = CreateSDKCall(hGameData, "IScriptVM", "ReleaseValue", _, SDKType_PlainOldData);
+	g_hSDKCallReleaseScript = CreateSDKCall(hGameData, "IScriptVM", "ReleaseScript", _, SDKType_PlainOldData);
 }
 
 HSCRIPT HScript_CreateTable()
@@ -153,4 +155,9 @@ void HScript_ReleaseValue(HSCRIPT pHScript)
 	
 	SDKCall(g_hSDKCallReleaseValue, GetScriptVM(), pValue.Address);
 	delete pValue;
+}
+
+void HScript_ReleaseScript(HSCRIPT pHScript)
+{
+	SDKCall(g_hSDKCallReleaseScript, GetScriptVM(), pHScript);
 }


### PR DESCRIPTION
Adds an extra parameter to `VScriptExecute`'s constructor to specify a script scope, or use root table by default.

Also added a `VScript_ReleaseScript` native to pair with `VScript_CompileScript(File)`. Since it exists on the interface, I figured it'd be best to stay on the safe side in case more specialized code takes place versus releasing it using `ReleaseValue`.

I also corrected the offsets for both `CompileScript` and `ReleaseScript` for TF2. Both have been tested on TF2 Windows and Linux, but I haven't tested in other games so `ReleaseScript`'s offsets in "#default" is just a guess. For TF2 specifically, I'm not sure if I should've used `ExtraOffsets`.

I used this code to test them along with the scopes:
```sourcepawn
Handle g_SDKCallGetScriptScope;

public void OnPluginStart()
{
	RegConsoleCmd("vscript_test", Command_Test);

	GameData gameData = new GameData("vscript_test");

	StartPrepSDKCall(SDKCall_Entity);
	PrepSDKCall_SetFromConf(gameData, SDKConf_Signature, "CBaseEntity::GetScriptScope");
	PrepSDKCall_SetReturnInfo(SDKType_PlainOldData, SDKPass_Plain);
	g_SDKCallGetScriptScope = EndPrepSDKCall();

	delete gameData;
}

ScriptStatus_t RunScript(const char[] code, HSCRIPT scope = view_as<HSCRIPT>(0))
{
	HSCRIPT script = VScript_CompileScript(code);
	if (!script)
	{
		return SCRIPT_ERROR;
	}

	VScriptExecute exec = new VScriptExecute(script, scope);
	ScriptStatus_t result = exec.Execute();
	delete exec;
	VScript_ReleaseScript(script);

	return result;
}

Action Command_Test(int client, int args)
{
	SetVariantString("self.ValidateScriptScope()");
	AcceptEntityInput(client, "RunScriptCode");

	HSCRIPT scope = SDKCall(g_SDKCallGetScriptScope, client);

	if (scope)
	{
		scope.SetValue("__test_value", FIELD_INTEGER, 7891);

		RunScript("__my_temp <- []; __my_temp.append(123)", scope);

		SetVariantString("__my_temp.append(64)");
		AcceptEntityInput(client, "RunScriptCode");

		SetVariantString("__DumpScope(1, self.GetScriptScope())");
		AcceptEntityInput(client, "RunScriptCode");
	}

	return Plugin_Handled;
}
```

vscript_test.txt:
```
"Games"
{
	"#default"
	{
		"Signatures"
		{
			"CBaseEntity::GetScriptScope"
			{
				"library"	"server"
				"linux"		"@_ZN11CBaseEntity14GetScriptScopeEv"
				"windows"	"\x8B\x89\x2A\x2A\x2A\x2A\x33\xC0\x83"
			}
		}
	}
}
```

Output:
```
   self = ([2] player)
   __test_value = 7891
   __vname = "_f730_player"
   __my_temp(ARRAY)
   [
      0 = 123
      1 = 64
   ]
   __vrefs = 1
```