### PR TITLE
Add several natives for managing with class

### DIFF
--- a/gamedata/vscript.txt
+++ b/gamedata/vscript.txt
@@ -42,6 +42,18 @@
 				"windows"	"0"
 			}
 			
+			"ScriptClassDesc_t::m_pszClassname"
+			{
+				"linux"		"4"
+				"windows"	"4"
+			}
+			
+			"ScriptClassDesc_t::m_pszDescription"
+			{
+				"linux"		"8"
+				"windows"	"8"
+			}
+			
 			"ScriptClassDesc_t::m_pBaseDesc"
 			{
 				"linux"		"12"
@@ -52,6 +64,12 @@
 			{
 				"linux"		"16"
 				"windows"	"16"
+			}
+			
+			"sizeof(ScriptClassDesc_t)"
+			{
+				"linux"		"52"
+				"windows"	"52"
 			}
 			
 			"ScriptFunctionBinding_t::m_pszScriptName"

--- a/gamedata/vscript.txt
+++ b/gamedata/vscript.txt
@@ -66,6 +66,12 @@
 				"windows"	"16"
 			}
 			
+			"ScriptClassDesc_t::m_pNextDesc"
+			{
+				"linux"		"48"
+				"windows"	"48"
+			}
+			
 			"sizeof(ScriptClassDesc_t)"
 			{
 				"linux"		"52"

--- a/scripting/include/vscript.inc
+++ b/scripting/include/vscript.inc
@@ -254,9 +254,36 @@ methodmap VScriptClass < Address
 {
 	// Gets the script name
 	// 
-	// @param buffer           Buffer to store name.
+	// @param buffer           Buffer to store script name.
 	// @param length           Size of buffer.
 	public native void GetScriptName(char[] buffer, int length);
+	
+	// Sets the script name
+	// 
+	// @param value            Script name to set.
+	public native void SetScriptName(const char[] value);
+	
+	// Gets the class name
+	// 
+	// @param buffer           Buffer to store class name.
+	// @param length           Size of buffer.
+	public native void GetClassName(char[] buffer, int length);
+	
+	// Sets the class name
+	// 
+	// @param value            Class name to set.
+	public native void SetClassName(const char[] value);
+	
+	// Gets the description
+	// 
+	// @param buffer           Buffer to store name.
+	// @param length           Size of buffer.
+	public native void GetDescription(char[] buffer, int length);
+	
+	// Sets the description
+	// 
+	// @param value            Description to set.
+	public native void SetDescription(const char[] value);
 	
 	// Get all of the functions used for this class
 	// 
@@ -274,6 +301,12 @@ methodmap VScriptClass < Address
 	// @param functionName     Function name.
 	// @return                 Address of VScriptFunction.
 	public native VScriptFunction CreateFunction();
+	
+	// Register this class as an instance. This does not require calling VScript_ResetScriptVM unless if modifications were made afterward.
+	// 
+	// @param instance         Name of an instance in script.
+	// @return                 Created HSCRIPT instance.
+	public native HSCRIPT RegisterInstance(const char[] instance);
 	
 	// Gets the class that this is based on, Address_Null if does not have base class
 	property VScriptClass Base
@@ -435,6 +468,15 @@ native ArrayList VScript_GetAllClasses();
  * @error                  Invalid class name
  */
 native VScriptClass VScript_GetClass(const char[] className);
+
+/**
+ * Gets VScriptClass from class or creates one if don't exist. VScriptClass.RegisterInstance must be called after params are filled.
+ * 
+ * @param className        Class name.
+ * 
+ * @return                 Address of VScriptClass, either existing or newly created
+ */
+native VScriptClass VScript_CreateClass(const char[] className);
 
 /**
  * Gets VScriptFunction from class

--- a/scripting/vscript/class.sp
+++ b/scripting/vscript/class.sp
@@ -1,21 +1,78 @@
 static int g_iClassDesc_ScriptName;
+static int g_iClassDesc_ClassName;
+static int g_iClassDesc_Description;
 static int g_iClassDesc_BaseDesc;
 static int g_iClassDesc_FunctionBindings;
+static int g_iClassDesc_sizeof;
 
 static int g_iFunctionBinding_sizeof;
 
 void Class_LoadGamedata(GameData hGameData)
 {
 	g_iClassDesc_ScriptName = hGameData.GetOffset("ScriptClassDesc_t::m_pszScriptName");
+	g_iClassDesc_ClassName = hGameData.GetOffset("ScriptClassDesc_t::m_pszClassname");
+	g_iClassDesc_Description = hGameData.GetOffset("ScriptClassDesc_t::m_pszDescription");
 	g_iClassDesc_BaseDesc = hGameData.GetOffset("ScriptClassDesc_t::m_pBaseDesc");
 	g_iClassDesc_FunctionBindings = hGameData.GetOffset("ScriptClassDesc_t::m_FunctionBindings");
-	
+	g_iClassDesc_sizeof = hGameData.GetOffset("sizeof(ScriptClassDesc_t)");
 	g_iFunctionBinding_sizeof = hGameData.GetOffset("sizeof(ScriptFunctionBinding_t)");
+}
+
+VScriptClass Class_Create()
+{
+	// TODO proper way to handle with memory?
+	
+	MemoryBlock hClass = new MemoryBlock(g_iClassDesc_sizeof);
+	
+	VScriptClass pClass = view_as<VScriptClass>(hClass.Address);
+	
+	hClass.Disown();
+	delete hClass;
+	
+	List_AddClass(pClass);
+	return pClass;
+}
+
+void Class_Init(VScriptClass pClass)
+{
+	for (int i = 0; i < g_iClassDesc_sizeof; i++)	// Make sure that all is cleared first
+		StoreToAddress(pClass + view_as<Address>(i), 0, NumberType_Int8);
+	
+	// Set strings as empty, but not null
+	Address pEmptyString = GetEmptyString();
+	StoreToAddress(pClass + view_as<Address>(g_iClassDesc_ScriptName), pEmptyString, NumberType_Int32);
+	StoreToAddress(pClass + view_as<Address>(g_iClassDesc_ClassName), pEmptyString, NumberType_Int32);
+	StoreToAddress(pClass + view_as<Address>(g_iClassDesc_Description), pEmptyString, NumberType_Int32);
 }
 
 void Class_GetScriptName(VScriptClass pClass, char[] sBuffer, int iLength)
 {
 	LoadPointerStringFromAddress(pClass + view_as<Address>(g_iClassDesc_ScriptName), sBuffer, iLength);
+}
+
+void Class_SetScriptName(VScriptClass pClass, int iParam)
+{
+	StoreNativePointerStringToAddress(pClass + view_as<Address>(g_iClassDesc_ScriptName), iParam);
+}
+
+void Class_GetClassName(VScriptClass pClass, char[] sBuffer, int iLength)
+{
+	LoadPointerStringFromAddress(pClass + view_as<Address>(g_iClassDesc_ClassName), sBuffer, iLength);
+}
+
+void Class_SetClassName(VScriptClass pClass, int iParam)
+{
+	StoreNativePointerStringToAddress(pClass + view_as<Address>(g_iClassDesc_ClassName), iParam);
+}
+
+void Class_GetDescription(VScriptClass pClass, char[] sBuffer, int iLength)
+{
+	LoadPointerStringFromAddress(pClass + view_as<Address>(g_iClassDesc_Description), sBuffer, iLength);
+}
+
+void Class_SetDescription(VScriptClass pClass, int iParam)
+{
+	StoreNativePointerStringToAddress(pClass + view_as<Address>(g_iClassDesc_Description), iParam);
 }
 
 ArrayList Class_GetAllFunctions(VScriptClass pClass)

--- a/scripting/vscript/function.sp
+++ b/scripting/vscript/function.sp
@@ -46,19 +46,11 @@ VScriptFunction Function_Create()
 
 void Function_Init(VScriptFunction pFunction, bool bClass)
 {
-	static Address pEmptyString;
-	if (!pEmptyString)
-	{
-		MemoryBlock hMemory = new MemoryBlock(1);
-		pEmptyString = hMemory.Address;
-		hMemory.Disown();
-		delete hMemory;
-	}
-	
 	for (int i = 0; i < g_iFunctionBinding_sizeof; i++)	// Make sure that all is cleared first
 		StoreToAddress(pFunction + view_as<Address>(i), 0, NumberType_Int8);
 	
 	// Set strings as empty, but not null
+	Address pEmptyString = GetEmptyString();
 	StoreToAddress(pFunction + view_as<Address>(g_iFunctionBinding_ScriptName), pEmptyString, NumberType_Int32);
 	StoreToAddress(pFunction + view_as<Address>(g_iFunctionBinding_FunctionName), pEmptyString, NumberType_Int32);
 	StoreToAddress(pFunction + view_as<Address>(g_iFunctionBinding_Description), pEmptyString, NumberType_Int32);

--- a/scripting/vscript/list.sp
+++ b/scripting/vscript/list.sp
@@ -58,8 +58,7 @@ MRESReturn List_RegisterClass(Address pScriptVM, DHookReturn hReturn, DHookParam
 		return MRES_Ignored;
 	
 	VScriptClass pClass = hParam.Get(1);
-	if (g_aClasses.FindValue(pClass) == -1)
-		g_aClasses.Push(pClass);
+	List_AddClass(pClass);
 	
 	return MRES_Ignored;
 }
@@ -75,6 +74,12 @@ void List_AddEntityScriptDesc(int iEntity)
 		g_aClasses.Push(pClass);
 		pClass = Class_GetBaseDesc(pClass);
 	}
+}
+
+void List_AddClass(VScriptClass pClass)
+{
+	if (g_aClasses.FindValue(pClass) == -1)
+		g_aClasses.Push(pClass);
 }
 
 ArrayList List_GetAllGlobalFunctions()

--- a/scripting/vscript/util.sp
+++ b/scripting/vscript/util.sp
@@ -50,6 +50,20 @@ int LoadStringLengthFromAddress(Address pString)
 	return iChar;
 }
 
+Address GetEmptyString()
+{
+	static Address pEmptyString;
+	if (!pEmptyString)
+	{
+		MemoryBlock hMemory = new MemoryBlock(1);
+		pEmptyString = hMemory.Address;
+		hMemory.Disown();
+		delete hMemory;
+	}
+	
+	return pEmptyString;
+}
+
 MemoryBlock CreateStringMemory(const char[] sBuffer)
 {
 	int iLength = strlen(sBuffer);

--- a/scripting/vscript_test.sp
+++ b/scripting/vscript_test.sp
@@ -164,6 +164,22 @@ public void OnMapStart()
 	AssertInt(TEST_ENTITY, VScript_HScriptToEntity(pEntity));
 	
 	/*
+	 * Create a new class instance
+	 */
+	
+	VScriptClass pClass = VScript_CreateClass("NewClass");
+	
+	pFunction = VScript_CreateClassFunction("NewClass", "InstanceFunction");
+	pFunction.SetParam(1, FIELD_INTEGER);
+	pFunction.Return = FIELD_FLOAT;
+	pFunction.SetFunctionEmpty();
+	pFunction.CreateDetour().Enable(Hook_Pre, Detour_InstanceFunction);
+	
+	HSCRIPT pInstance = pClass.RegisterInstance("InstanceName");
+	
+	AssertInt(TEST_FLOAT, SDKCall(pFunction.CreateSDKCall(), pInstance.Instance, TEST_INTEGER));
+	
+	/*
 	 * Test virtual function
 	 */
 	
@@ -194,7 +210,7 @@ public void OnMapStart()
 	int iLength = aList.Length;
 	for (int i = 0; i < iLength; i++)
 	{
-		VScriptClass pClass = aList.Get(i);
+		pClass = aList.Get(i);
 		CheckFunctions(pClass.GetAllFunctions());
 	}
 	
@@ -351,6 +367,13 @@ public MRESReturn Detour_FindByClassname(Address pThis, DHookReturn hReturn, DHo
 	hParam.GetString(2, sBuffer, sizeof(sBuffer));
 	AssertString(TEST_CLASSNAME, sBuffer);
 	return MRES_Ignored;
+}
+
+public MRESReturn Detour_InstanceFunction(Address pThis, DHookReturn hReturn, DHookParam hParam)
+{
+	AssertInt(TEST_INTEGER, hParam.Get(1));
+	hReturn.Value = TEST_FLOAT;
+	return MRES_Supercede;
 }
 
 public MRESReturn Hook_GetMaxHealth(int iEntity, DHookReturn hReturn)


### PR DESCRIPTION
Several natives added:
- `VScriptClass.SetScriptName`
- `VScriptClass.GetClassName`
- `VScriptClass.SetClassName`
- `VScriptClass.GetDescription`
- `VScriptClass.SetDescription`
- `VScriptClass.RegisterInstance`
- `VScript_CreateClass`

"ScriptName" and "ClassName" are usually the same, but some can be different from eachother (e.g. `CEntities` as script and `CScriptEntityIterator`, as class, while `Entities` is actually used as a name in script).

`vscript_test.sp` have an example on how to create an instance to make use of it. string param in `VScript_CreateClass` can be anything, probably...... while string param in `VScriptClass.RegisterInstance` are actually used in script files to call functions, aka `InstanceName.InstanceFunction(322)`.

No support yet for creating non-instance class for an actual entity class. That'll take more work and effort, so just instance will do for now.